### PR TITLE
change Authorization header to IFTTT-Channel-Key

### DIFF
--- a/iftttest
+++ b/iftttest
@@ -85,9 +85,9 @@ var Channel = {
 
     // if set, client secret will always be sent
     if (Channel.config.secret) {
-      var auth = "Bearer " + Channel.config.secret;
-      console.log("Authorization: " + auth)
-      options.headers["Authorization"] = auth;
+      var auth = Channel.config.secret;
+      console.log("IFTTT-Channel-Key: " + auth)
+      options.headers["IFTTT-Channel-Key"] = auth;
     }
 
     if (body) {


### PR DESCRIPTION
Changes per @acco's request. Only Authorization header needed to be changed as the ifttt/meta response key is never checked.
